### PR TITLE
Refactor service.js and plugin constructor

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,6 @@
+import {name} from '../package.json';
 import i18n from './i18n'
 export default {
+  name,
   i18n
 }

--- a/index.js
+++ b/index.js
@@ -1,37 +1,28 @@
 import pluginConfig from './config';
+import Service from './service';
 const {base, inherit} = g3wsdk.core.utils;
-const {Plugin} = g3wsdk.core.plugin;
-const {addI18nPlugin} = g3wsdk.core.i18n;
-const Service = require('./service');
+const {Plugin:BasePlugin} = g3wsdk.core.plugin;
 
-const _Plugin = function() {
-  base(this);
-  this.name = 'eleprofile';
-  this.init = function() {
-    // add i18n of the plugin
-    addI18nPlugin({
-      name: this.name,
-      config: pluginConfig.i18n
-    });
-    // set catalog initial tab
-    this.config = this.getConfig();
-    this.setService(Service);
+const Plugin = function() {
+  const {name, i18n} = pluginConfig;
+  base(this, {
+    name,
+    service: Service,
+    i18n
+  });
+  if (this.registerPlugin(this.config.gid)) {
     this.service.init(this.config);
-    this.registerPlugin(this.config.gid);
-    // create API
-    this.setReady(true);
-  };
-  //called when plugin is removed
-  this.unload = function() {
-    this.service.clear();
-  };
+  }
+  this.setReady(true);
 };
 
-inherit(_Plugin, Plugin);
+inherit(Plugin, BasePlugin);
 
-(function(plugin){
-  plugin.init();
-})(new _Plugin);
+//called when plugin is removed
+Plugin.prototype.unload = function() {
+  this.service.clear();
+};
 
+new Plugin();
 
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "eleprofile",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Elevation Profile plugin",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "start": "gulp watch",
+    "watch": "gulp watch",
     "build": "gulp build"
   },
   "repository": {

--- a/service.js
+++ b/service.js
@@ -7,248 +7,212 @@ const t = g3wsdk.core.i18n.tPlugin;
 
 function ElevationProfileService() {
   base(this);
-  this.init = function(config={}) {
-    this.chartColor = GUI.skinColor;
-    this.config = config;
-    // add vue property to in add elevention chart element
-    this.config.layers && this.config.layers.forEach(layerObj => layerObj._vue = {});
-    this._mapService = GUI.getService('map');
-    this.keySetters = {};
-    const queryresultsComponent = GUI.getComponent('queryresults');
-    this.queryresultsService = queryresultsComponent.getService();
-    this.keySetters.openCloseFeatureResult = this.queryresultsService.onafter('openCloseFeatureResult', ({open, layer, feature, container})=>{
-      const layerObj = this.config.layers.find(layerObj => {
-        const {layer_id: layerId} = layerObj;
-        return layer.id === layerId;
-      });
-      layerObj && this.showHideChartComponent({
-        open,
-        container,
-        layerObj,
-        fid: feature.attributes['g3w_fid']
-      })
-    })
-  };
-
-  this.getConfig = function(){
-    return this.config;
-  };
-
-  this.getUrls = function() {
-    return this.config.urls;
-  };
-
-  this.createLoadingComponentDomElement = function(){
-    const loadingComponent = Vue.extend({
-      template: `<bar-loader :loading="true"></bar-loader>`
-    });
-    return new loadingComponent().$mount().$el;
-  };
-
-  this.showHideChartComponent = async function({open, layerObj, container, fid}={}) {
-    if (open) {
-      const {api, layer_id: layerId} = layerObj;
-      const barLoadingDom = this.createLoadingComponentDomElement();
-      try {
-        container.append(barLoadingDom);
-        const {component, error} = await this.getChartComponent({api, layerId, fid});
-        if (error) return;
-        const vueComponentObject = Vue.extend(component);
-        layerObj._vue[fid] = new vueComponentObject();
-        layerObj._vue[fid].$once('hook:mounted', async function(){
-          container.append(this.$el);
-          GUI.emit('resize');
-        });
-        layerObj._vue[fid].$mount();
-      } catch (error){
-        return error;
-      } finally {
-        barLoadingDom.remove();
-      }
-    } else {
-      if (layerObj._vue[fid]) {
-        layerObj._vue[fid].$destroy();
-        layerObj._vue[fid].$el.remove();
-        layerObj._vue[fid] = undefined;
-      }
-    }
-  };
-
-  this.getChartComponent = async function({api, layerId, fid}={}) {
-    try {
-      const response = await this.getElevationData({api, layerId, fid});
-      const data = response.result && response.profile;
-      if (data) {
-        const graphData = {
-          x: ['x'],
-          y: ['y'],
-          minX:  9999999,
-          maxX: -9999999,
-          minY:  9999999,
-          maxY: -9999999
-        };
-        for (let i=0; i < data.length; i++) {
-          const _data = data[i];
-          const x = _data[3];
-          const y = _data[2];
-          graphData.minX = x < graphData.minX ? x : graphData.minX;
-          graphData.minY = y < graphData.minY ? y : graphData.minY;
-          graphData.maxX = x > graphData.maxX ? x : graphData.maxX;
-          graphData.maxY = y > graphData.maxY ? y : graphData.maxY;
-          graphData.x.push(x);
-          graphData.y.push(y);
-        }
-        const self = this;
-        const map = this._mapService.getMap();
-        let hideHightlightFnc = () => {};
-        return {
-          data,
-          id: t('eleprofile.chart.title'),
-          component: ChartsFactory.build({
-            type: 'c3:lineXY',
-            hooks: {
-              created() {
-                this.setConfig({
-                  onmouseout() {
-                    hideHightlightFnc()
-                  },
-                  title: {
-                    text: t('eleprofile.chart.title'),
-                    position: 'top-center',
-                  },
-                  padding: {
-                    top: 40,
-                    bottom: 30,
-                    right: 30
-                  },
-                  zoom: {
-                    enabled: true,
-                    rescale: true,
-                  },
-                  data: {
-                    selection: {
-                      enabled: false,
-                      draggable: true
-                    },
-                    x: 'x',
-                    y: 'y',
-                    types: {
-                      y: 'area'
-                    },
-                    colors: {
-                      x: self.chartColor,
-                      y: self.chartColor
-                    },
-                    columns: [
-                      graphData.x,
-                      graphData.y
-                    ],
-                    onmouseout(evt) {
-                      hideHightlightFnc();
-                    },
-                    onclick({index}) {
-                      const [x, y] = data[index];
-                      map.getView().setCenter([x,y]);
-                    },
-                  },
-                  legend: {
-                    show: false
-                  },
-                  tooltip:{
-                    format: {
-                      title(d) {
-                        return `${t('eleprofile.chart.tooltip.title')}: ${data[d][3]}`
-                      },
-                    },
-                    contents: function (_data, color) {
-                      const index = _data[0].index;
-                      const [x, y, value] = data[index];
-                      const point_geom = new ol.geom.Point(
-                        [x, y]
-                      );
-                      self._mapService.highlightGeometry(point_geom, {
-                        zoom: false,
-                        hide: function(callback) {
-                          hideHightlightFnc = callback;
-                        },
-                        style: new ol.style.Style({
-                          image: new ol.style.RegularShape({
-                            fill: new ol.style.Fill({color: 'white' }),
-                            stroke: new ol.style.Stroke({color: self.chartColor, width: 3}),
-                            points: 3,
-                            radius: 12,
-                            angle: 0
-                          })
-                        })
-                      });
-                      return `<div style="font-weight: bold; border:2px solid; background-color: #ffffff; padding: 3px;border-radius: 3px;" 
-                          class="skin-border-color skin-color">${value.toFixed(2)}(m)</div>`
-                    }
-                  },
-                  axis: {
-                    x: {
-                      max: graphData.maxX + 2,
-                      min: graphData.minX - 2,
-                      label: {
-                        text: t('eleprofile.chart.labels.x'),
-                        position: 'outer-center'
-                      },
-                      tick: {
-                        fit: false,
-                        count: 4,
-                        format: function (value) {
-                          return value.toFixed(2);
-                        }
-                      }
-                    },
-                    y: {
-                      max: graphData.maxY + 5,
-                      min: graphData.minY - 5,
-                      label: {
-                        text: t('eleprofile.chart.labels.y'),
-                        position: 'outer-middle'
-                      },
-                      tick: {
-                        count: 5,
-                        format: function (value) {
-                          return value.toFixed(2);
-                        }
-                      }
-                    }
-                  }
-                });
-              }
-            }
-          })
-        }
-      }
-    } catch (err) {
-      return {
-        error: true
-      }
-    }
-  };
-
-  this.getElevationData = async function({api, layerId, fid}={}) {
-    const url = `${api}${layerId}/${fid}`;
-    const data = {
-      result: false
-    };
-    try {
-      const response = await XHR.get({
-        url
-      });
-      data.profile = response.profile;
-      data.result = true;
-    } catch(error){}
-    return data;
-  };
-
-  this.clear = function() {
-    this.queryresultsService.un('openCloseFeatureResult', this.keySetters.openCloseFeatureResult);
-  }
 }
 
 inherit(ElevationProfileService, PluginService);
 
-module.exports = new ElevationProfileService;
+const proto = ElevationProfileService.prototype;
+
+proto.init = function(config={}) {
+  this.config              = config;
+  this.chartColor          = GUI.skinColor;
+  this._mapService         = GUI.getService('map');
+  this.queryresultsService = GUI.getService('queryresults');
+  this.keySetters          = {
+    openCloseFeatureResult: this.queryresultsService.onafter(
+      'openCloseFeatureResult', ({open, layer, feature, container}) => {
+        const selectedLayer = this.config.layers.find(l => layer.id === l.layer_id);
+        if (selectedLayer) {
+          this.toggleChartComponent({
+            open,
+            container,
+            layer: selectedLayer,
+            fid: feature.attributes['g3w_fid']
+          })
+        }
+      })
+  };
+  // add "_vue" property to each layer have a reference of the elevation chart element
+  if (this.config.layers) {
+    this.config.layers.forEach(layer => layer._vue = {});
+  }
+};
+
+proto.toggleChartComponent = async function({open, layer, container, fid}) {
+  let chart = layer._vue[fid];
+  if (open) {
+    const loadingBar = new (Vue.extend({ template: `<bar-loader :loading="true"></bar-loader>` }))().$mount().$el;
+    try {
+      container.append(loadingBar);
+      const component = await this.getChartComponent({
+        api: layer.api,
+        layerId: layer.layer_id,
+        fid
+      });
+      chart = new (Vue.extend(component))();
+      chart.$once('hook:mounted', async function() {
+        container.append(this.$el);
+        GUI.emit('resize');
+      });
+      chart.$mount();
+    } catch (error) {
+      return error;
+    } finally {
+      loadingBar.remove();
+    }
+  } else if (chart) {
+    chart.$destroy();
+    chart.$el.remove();
+    chart = undefined;
+  }
+};
+
+proto.parseGraphData = function(data) {
+  const getMin    = (x1, x2) => x1 < x2 ? x1 : x2;
+  const getMax    = (x1, x2) => x1 > x2 ? x1 : x2;
+  const graphData = {
+    x: ['x'],
+    y: ['y'],
+    minX:  9999999,
+    maxX: -9999999,
+    minY:  9999999,
+    maxY: -9999999
+  };
+  for (let i=0; i < data.length; i++) {
+    const x = data[i][3];
+    const y = data[i][2];
+    graphData.minX = getMin(x, graphData.minX);
+    graphData.minY = getMin(y, graphData.minY);
+    graphData.maxX = getMax(x, graphData.maxX);
+    graphData.maxY = getMax(y, graphData.maxY);
+    graphData.x.push(x);
+    graphData.y.push(y);
+  }
+  return graphData;
+};
+
+proto.getChartComponent = async function({api, layerId, fid}) {
+  const data             = await this.getElevationData({api, layerId, fid});
+  const graphData        = this.parseGraphData(data);
+  const chartColor       = this.chartColor;
+  const setMapCenter     = ({index}) => {
+    const [x, y] = data[index];
+    this._mapService.getMap().getView().setCenter([x,y]);
+  };
+  const addMapMarker     = ({x, y}) => {
+    const point = new ol.geom.Point([x, y]);
+    this._mapService.highlightGeometry(point, {
+      // TODO: update map marker position instead of removing it
+      hide: (callback) => removeMapMarker = callback,
+      style: new ol.style.Style({
+        image: new ol.style.RegularShape({
+          fill: new ol.style.Fill({color: 'white'}),
+          stroke: new ol.style.Stroke({color: chartColor, width: 3}),
+          points: 3,
+          radius: 12,
+          angle: 0
+        })
+      }),
+      zoom: false
+    });
+  };
+  let removeMapMarker    = () => {};
+  const chartFactoryOpts = {
+    type: 'c3:lineXY',
+    hooks: {
+      created() {
+        // update "lineXY.js" config
+        this.setConfig({
+          // TODO: update map marker position instead of removing it
+          onmouseout: removeMapMarker,
+          title: {
+            text: t('eleprofile.chart.title'),
+            position: 'top-center',
+          },
+          padding: {
+            top: 40,
+            bottom: 30,
+            right: 30
+          },
+          zoom: {
+            enabled: true,
+            rescale: true,
+          },
+          data: {
+            selection: {
+              enabled: false,
+              draggable: true
+            },
+            x: 'x',
+            y: 'y',
+            types: {
+              y: 'area'
+            },
+            colors: {
+              x: chartColor,
+              y: chartColor
+            },
+            columns: [
+              graphData.x,
+              graphData.y
+            ],
+            // TODO: update map marker position instead of removing it
+            onmouseout: removeMapMarker,
+            onclick: setMapCenter,
+          },
+          legend: {
+            show: false
+          },
+          tooltip: {
+            format: {
+              title: (d) => `${t('eleprofile.chart.tooltip.title')}: ${data[d][3]}`,
+            },
+            contents: (d) => {
+              const [x, y, value] = data[d[0].index];
+              addMapMarker({x, y});
+              return `<div style="font-weight: bold; border:2px solid; background-color: #ffffff; padding: 3px;border-radius: 3px;" class="skin-border-color skin-color">${value.toFixed(2)} (m)</div>`
+            }
+          },
+          axis: {
+            x: {
+              max: graphData.maxX + 2,
+              min: graphData.minX - 2,
+              label: {
+                text: t('eleprofile.chart.labels.x'),
+                position: 'outer-center'
+              },
+              tick: {
+                fit: false,
+                count: 4,
+                format: (value) => value.toFixed(2)
+              }
+            },
+            y: {
+              max: graphData.maxY + 5,
+              min: graphData.minY - 5,
+              label: {
+                text: t('eleprofile.chart.labels.y'),
+                position: 'outer-middle'
+              },
+              tick: {
+                count: 5,
+                format: (value) => value.toFixed(2)
+              }
+            }
+          }
+        });
+      }
+    }
+  };
+  return ChartsFactory.build(chartFactoryOpts);
+};
+
+proto.getElevationData = async function({api, layerId, fid}) {
+  return (await XHR.get({ url: `${api}${layerId}/${fid}` })).profile;
+};
+
+proto.clear = function() {
+  this.queryresultsService.un('openCloseFeatureResult', this.keySetters.openCloseFeatureResult);
+}
+
+export default new ElevationProfileService();


### PR DESCRIPTION
- refactor plugin.js constructor (according to: https://github.com/g3w-suite/g3w-client/pull/64)
- bump version to `1.1.0`
- rename `npm run start` script into `npm run watch`
- remove `Service.getConfig` method
- remove `Service.getUrls` method
- refactor and rename `Service.showHideChartComponent` into `Service.toggleChartComponent`
- remove `Service.createLoadingComponentDomElement` method
- refactor `Service.getChartComponent` and add `Service.parseGraphData` helper method
- refactor and change returned object type of `Service.getElevationData`
- deprecate service.js commonjs module definition (make use of native `esm` modules instead)
